### PR TITLE
Fix broken reactivate prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ export default class QRCodeScanner extends Component {
       this._setScanning(true);
       this.props.onRead(e)
       if (this.props.reactivate) {
-        setTimeout(() => (this.setScanning(false)), this.props.reactivateTimeout);
+        setTimeout(() => (this._setScanning(false)), this.props.reactivateTimeout);
       }
     }
     return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qrcode-scanner",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A QR code scanner for React Native.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Here's a tiny fix for the `reactivate` prop. When used it was erroring out because `this.setScanning` wasn't defined. `this._setScanning` is the correct function name. This fixes the typo and increments the patch number.