### PR TITLE
Remove unnecessary marginTop and a little clean up

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,9 @@
 
 import React, { Component, PropTypes } from 'react';
 import {
-  AppRegistry,
   StyleSheet,
   Dimensions,
-  Text,
-  Navigator,
   Vibration,
-  Linking,
   Animated,
   Easing,
   View
@@ -83,7 +79,6 @@ export default class QRCodeScanner extends Component {
         setTimeout(() => (this._setScanning(false)), this.props.reactivateTimeout);
       }
     }
-    return;
   }
 
   _renderTopContent() {
@@ -155,28 +150,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     width: Dimensions.get('window').width,
-  },
-
-  centerText: {
-    flex: 1,
-    fontSize: 18,
-    padding: 32,
-    color: '#777',
-  },
-
-  textBold: {
-    fontWeight: '500',
-    color: '#000',
-  },
-
-  buttonText: {
-    fontSize: 21,
-    color: 'rgb(0,122,255)',
-  },
-
-  buttonTouchable: {
-    // backgroundColor: 'pink',
-    padding: 16,
   },
 
   camera: {

--- a/index.js
+++ b/index.js
@@ -133,10 +133,7 @@ export default class QRCodeScanner extends Component {
 
   render() {
     return (
-      <View style={{
-          flex: 1,
-          marginTop: 64,
-        }}>
+      <View style={styles.mainContainer}>
         <View style={[styles.infoView, this.props.topViewStyle]}>
           {this._renderTopContent()}
         </View>
@@ -150,6 +147,9 @@ export default class QRCodeScanner extends Component {
 }
 
 const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1
+  },
   infoView: {
     flex: 2,
     justifyContent: 'center',


### PR DESCRIPTION
Hello,

as discussed in #16, I removed the marginTop in the mainContainer.

I also did a little bit of clean up for unused imports, unused styles and removed a no-op `return` statement.

Works great on Android with this simple example:

```jsx
import React, { Component } from 'react';
import { AppRegistry, Dimensions } from 'react-native';
import QRCodeScanner from './react-native-qrcode-scanner';

class TestApp extends Component {
  render() {
    return (
      <QRCodeScanner
        cameraStyle={{ height: Dimensions.get('window').height }}
      />
    );
  }
}

AppRegistry.registerComponent('testApp', () => TestApp);
```

![image](https://cloud.githubusercontent.com/assets/11057256/26278971/f98e86d2-3da7-11e7-8ec5-fca90ddc68d9.png)

No way to test on iOS though.


By the way, I also noticed that there were unused references to a marker, but I figured it might have been a work in progress so I didn't remove those references in this PR. If they can be removed, let me know and I'll update my PR.