### PR TITLE
Move react native camera to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ With Android 7 and higher you need to add the "Vibration" permission to your And
 
 #### react-native-camera
 [react-native-camera](https://github.com/lwansbrough/react-native-camera) is a dependency for this package that you'll need to add to your project. To install, run the following commands:
-  1. `npm install react-native-camera@https://github.com/lwansbrough/react-native-camera.git --save`
+  1. `npm install react-native-camera --save`
   2. `react-native link react-native-camera`
 
 ### To install and start using react-native-qrcode-scanner:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/moaazsidat/react-native-qrcode-scanner/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react-native-camera": "^0.10.0"
   },
   "homepage": "https://github.com/moaazsidat/react-native-qrcode-scanner#readme"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/moaazsidat/react-native-qrcode-scanner/issues"
   },
   "dependencies": {
-    "react-native-camera": "github:lwansbrough/react-native-camera"
+    "react-native-camera": "^0.10.0"
   },
   "homepage": "https://github.com/moaazsidat/react-native-qrcode-scanner#readme"
 }


### PR DESCRIPTION
This will ensure their is only 1 version of react-native-camera per app.