### PR TITLE
Fix camera permission check on Android API < 23

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,8 @@ export default class QRCodeScanner extends Component {
           'message':  this.props.permissionDialogMessage, 
         }
       ).then((granted) => {
-        this.setState({ isAuthorized: granted ===  PermissionsAndroid.RESULTS.GRANTED, isAuthorizationChecked: true })
+        const isAuthorized = Platform.Version >= 23 ? granted === PermissionsAndroid.RESULTS.GRANTED : granted === true;
+        this.setState({ isAuthorized, isAuthorizationChecked: true })
       })
     } else {
       this.setState({ isAuthorized: true, isAuthorizationChecked: true })


### PR DESCRIPTION
When using [`PermissionsAndroid.request()`](https://facebook.github.io/react-native/docs/permissionsandroid.html) on Android API < 23, it does not return `PermissionsAndroid.RESULTS.GRANTED` aka `"granted"`, but a boolean. This PR checks the API version and correctly checks the permission result.