### PR TITLE
Allow passing props to the Camera component

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ default: `'Need camera permission'`
 
 Use this to setting permission dialog message (Android only).
 
+#### `cameraProps`
+propType: `object`
+
+Properties to be passed to the `Camera` component.
+
+
 <!--## Contriubting-->
 <!--See [CONTRIBUTING.md](CONTRIBUTING.md)-->
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ export default class QRCodeScanner extends Component {
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
     checkAndroid6Permissions: PropTypes.bool,
-    cameraProps: PropTypes.object
+    cameraProps: PropTypes.object,
   };
 
   static defaultProps = {
@@ -91,6 +91,7 @@ export default class QRCodeScanner extends Component {
     permissionDialogTitle: 'Info',
     permissionDialogMessage: 'Need camera permission',
     checkAndroid6Permissions: false,
+    cameraProps: {},
   };
 
   constructor(props) {

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ export default class QRCodeScanner extends Component {
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
     checkAndroid6Permissions: PropTypes.bool,
+    cameraProps: PropTypes.object
   };
 
   static defaultProps = {
@@ -221,6 +222,7 @@ export default class QRCodeScanner extends Component {
               style={[styles.camera, this.props.cameraStyle]}
               onBarCodeRead={this._handleBarCodeRead.bind(this)}
               type={this.props.cameraType}
+              {...this.props.cameraProps}
             >
               {this._renderCameraMarker()}
             </Camera>
@@ -232,6 +234,7 @@ export default class QRCodeScanner extends Component {
           type={cameraType}
           style={[styles.camera, this.props.cameraStyle]}
           onBarCodeRead={this._handleBarCodeRead.bind(this)}
+          {...this.props.cameraProps}
         >
           {this._renderCameraMarker()}
         </Camera>


### PR DESCRIPTION
I needed to access one of the properties of `Camera` (`ratio`) but couldn't. This PR adds this possibility, via the `cameraProps` property. An example:
```javascript
<QRCodeScanner
  ...
  cameraProps={{
    ratio: "1:1"
  }}
/>
```
