### PR TITLE
Add prop to disable vibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ default: `true`
 When set to `true` this ensures that the camera view fades in after the initial load up instead of being rendered immediately.
 Set this to false to prevent the animated fade in of the camera view.
 
+#### `vibrate`
+propType: `bool`
+default: `true`
+
+Use this to disable vibration.
+
 #### `reactivate`
 propType: `bool`
 default: `false`

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ export default class QRCodeScanner extends Component {
     reactivate: PropTypes.bool,
     reactivateTimeout: PropTypes.number,
     fadeIn: PropTypes.bool,
+    vibrate: PropTypes.bool,
     showMarker: PropTypes.bool,
     cameraType: PropTypes.oneOf(['front','back']),
     customMarker: PropTypes.element,
@@ -53,6 +54,7 @@ export default class QRCodeScanner extends Component {
     reactivate: false,
     reactivateTimeout: 0,
     fadeIn: true,
+    vibrate: true,
     showMarker: false,
     cameraType: 'back',
     notAuthorizedView: (
@@ -147,7 +149,9 @@ export default class QRCodeScanner extends Component {
 
   _handleBarCodeRead(e) {
     if (!this.state.scanning) {
-      Vibration.vibrate();
+      if (this.props.vibrate) {
+        Vibration.vibrate();
+      }
       this._setScanning(true);
       this.props.onRead(e)
       if (this.props.reactivate) {


### PR DESCRIPTION
I am using this library for a use case where I don't want scans to be repeated. I could manage that in my app by comparing the scan result against the last scan.
I need to disable vibration when I don't want to register a scan, hence I've added a prop _vibrate_ which can be used to disable vibration.

**Notes :**
- _vibration_ prop defaults to true, to preserve the default behaviour of the library.
- This does not change with vibrate permissions.
- Docs have been updated.
