### PR TITLE
Fix warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,6 +224,7 @@ export default class QRCodeScanner extends Component {
               style={[styles.camera, this.props.cameraStyle]}
               onBarCodeRead={this._handleBarCodeRead.bind(this)}
               type={this.props.cameraType}
+              captureAudio={false}
               {...this.props.cameraProps}
             >
               {this._renderCameraMarker()}
@@ -236,6 +237,7 @@ export default class QRCodeScanner extends Component {
           type={cameraType}
           style={[styles.camera, this.props.cameraStyle]}
           onBarCodeRead={this._handleBarCodeRead.bind(this)}
+          captureAudio={false}
           {...this.props.cameraProps}
         >
           {this._renderCameraMarker()}


### PR DESCRIPTION
To prevent the warning:

```
The 'captureAudio' property set on RNCamera instance but 'RECORD_AUDIO' permissions not defined in the applications 'AndroidManifest.xml'. If you want to record audio you will have to add '' to your 'AndroidManifest.xml'. Otherwise you should set the 'captureAudio' property on the component instance to 'false'.
```