### PR TITLE
Set Capture Audio to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,6 +221,7 @@ export default class QRCodeScanner extends Component {
             }}
           >
             <Camera
+              captureAudio={false}
               style={[styles.camera, this.props.cameraStyle]}
               onBarCodeRead={this._handleBarCodeRead.bind(this)}
               type={this.props.cameraType}
@@ -233,6 +234,7 @@ export default class QRCodeScanner extends Component {
       }
       return (
         <Camera
+          captureAudio={false}
           type={cameraType}
           style={[styles.camera, this.props.cameraStyle]}
           onBarCodeRead={this._handleBarCodeRead.bind(this)}


### PR DESCRIPTION
To avoid warning yellow boxes, assign the value "false" to the captureAudio property of the Camera component. All tests was successful.