### PR TITLE
Fix permissions for Android API < 23

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,10 +125,7 @@ export default class QRCodeScanner extends Component {
         title: this.props.permissionDialogTitle,
         message: this.props.permissionDialogMessage,
       }).then(granted => {
-        const isAuthorized =
-          Platform.Version >= 23
-            ? granted === PermissionsAndroid.RESULTS.GRANTED
-            : granted === "granted";
+        const isAuthorized = granted === PermissionsAndroid.RESULTS.GRANTED;
 
         this.setState({ isAuthorized, isAuthorizationChecked: true });
       });

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ export default class QRCodeScanner extends Component {
         const isAuthorized =
           Platform.Version >= 23
             ? granted === PermissionsAndroid.RESULTS.GRANTED
-            : granted === true;
+            : granted === "granted";
 
         this.setState({ isAuthorized, isAuthorizationChecked: true });
       });


### PR DESCRIPTION
This PR aims to fix a bug on permissions result for Android devices.

### the problem
When it asks for Camera permissions it checks if the result === **true** for all devices have an API level < 23, but [PermissionStatus](https://github.com/facebook/react-native/blob/91f139b94118fe8db29728ea8ad855fc4a13f743/Libraries/PermissionsAndroid/NativePermissionsAndroid.js) cannot be a boolean (only a string). As the [documentation](https://facebook.github.io/react-native/docs/permissionsandroid) says for devices with API < 23 the check methods return always true, not the request

> On devices before SDK version 23, the permissions are automatically granted if they appear in the manifest, so check should always result to true and request should always resolve to PermissionsAndroid.RESULTS.GRANTED.

### before
When it asks for Camera permissions it checks if the result === **"granted"** for all devices have an API level > 23, otherwise it checks if the result === **true** and the permission will result always as denied

### after
When it asks for Camera permissions it checks if the result === **"granted"** 