### PR TITLE
fix "incorrect peer dependency" warning on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "^1.12.1"
   },
   "peerDependencies": {
-    "react-native-camera": "^1.0.2"
+    "react-native-camera": ">=1.0.2"
   },
   "homepage": "https://github.com/moaazsidat/react-native-qrcode-scanner#readme",
   "lint-staged": {


### PR DESCRIPTION
Currently when installing `react-native-qrcode-scanner` with latest version of `react-native-camera` package Yarn prints following waring:

> " > react-native-qrcode-scanner@1.3.1" has incorrect peer dependency "react-native-camera@^1.0.2".

Changing from `^` to `>=` in `react-native-camera` version string fixes that warning (allows using higher major version of that package). 

Latest releases of `react-native-camera` working just fine and as I understand `1.0.2` was declared as an oldest supported version. Please correct me if I'm wrong.