### PR TITLE
Use native driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,8 @@ export default class QRCodeScanner extends Component {
         Animated.delay(1000),
         Animated.timing(this.state.fadeInOpacity, {
           toValue: 1,
-          easing: Easing.inOut(Easing.quad)
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true
         })
       ]).start();
     }


### PR DESCRIPTION
Since React Native 0.62, a yellowbox warning will appear if `useNativeDriver` is not specified.
We can use the native driver here since we're only animating opacity. 👍 

Fixes https://github.com/moaazsidat/react-native-qrcode-scanner/issues/242