### PR TITLE
Add react-native-permissions setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,15 @@ If using an older version of this module with RCTCamera you will need to follow 
 
 ### To install and start using react-native-qrcode-scanner:
 
-```
-npm install react-native-qrcode-scanner --save
-npm install react-native-permissions --save
-```
-
-```
-react-native link react-native-qrcode-scanner
-react-native link react-native-permissions
-```
+1. `npm install react-native-qrcode-scanner --save`
+2. `react-native link react-native-qrcode-scanner`
 
 #### react-native-permissions
+
+You will also need to install react-native-permissions to handle camera related permissions
+
+1. `npm install react-native-permissions --save`
+2. `react-native link react-native-permissions`
 
 For iOS, as part of the [react-native-permissions setup](https://github.com/react-native-community/react-native-permissions#setup) you will need to add the following code to your `Podfile`
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ react-native link react-native-qrcode-scanner
 react-native link react-native-permissions
 ```
 
+#### react-native-permissions
+
+For iOS, as part of the [react-native-permissions setup](https://github.com/react-native-community/react-native-permissions#setup) you will need to add the following code to your `Podfile`
+
+```
+permissions_path = '../node_modules/react-native-permissions/ios'
+pod 'Permission-Camera', :path => "#{permissions_path}/Camera.podspec"
+```
+
+You may also need to reset your simulator data after adding those permissions `Device -> Erase All Content and Settings...`
+
 ## Usage
 
 To use react-native-qrcode-scanner, `import` the `react-native-qrcode-scanner` module and use the `<QRCodeScanner />` tag. More usage examples can be seen under the `examples/` folder.


### PR DESCRIPTION
#254 

Not an ideal placement, but didn't make sense to reference react-native-permissions before instructions to install it.