### PR TITLE
Fix for full screen height issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,7 +324,7 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'center',
 		backgroundColor: 'transparent',
-		height: Dimensions.get('window').width,
+		height: Dimensions.get('window').height,
 		width: Dimensions.get('window').width,
 	},
 


### PR DESCRIPTION
After updating to `v1.4.1` could not get full screen height for the camera.

Found out that the `Animated.View` wrapping the CameraComponent gets `styles.camera.height` (line 327) only that 
its hard coded to `Dimensions.get('window').width` 

So even if I would use `cameraStyle` prop to try to control its height its parent still had height as screen width.

The only change in this PR is changing `styles.camera.height` to screen height instead of width.