### PR TITLE
Fix for property "buttonPositive"

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ export default class QRCodeScanner extends Component {
 			PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, {
 				title: this.props.permissionDialogTitle,
 				message: this.props.permissionDialogMessage,
+				buttonPositive: this.props.buttonPositive,
 			}).then(granted => {
 				const isAuthorized = granted === PermissionsAndroid.RESULTS.GRANTED;
 


### PR DESCRIPTION
I noticed this bug during my development, the bug happens when using prop `checkAndroid6Permissions`, the permission alert is displayed without the "OK" button.

The only change was to put `buttonPositive` where check if `checkAndroid6Permissions` in `componentDidMount` 