### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,51 +1,14 @@
-/* Type definitions for react-native-qrcode-scanner 1.1.0
+/* Type definitions for react-native-qrcode-scanner 1.5.0
  * Definitions by: Jan Hesters <https://github.com/janhesters/>
+ * Updated by: Abdullah Hilson <https://github.com/abumalick/>
  * If you modify this file, put your GitHub info here as well (for easy contacting purposes)
  */
 import { Component } from 'react';
 import { ViewStyle, StyleProp } from 'react-native';
-import { RNCameraProps } from 'react-native-camera';
-
-type BarCodeType = Readonly<{
-  aztec: any;
-  code128: any;
-  code39: any;
-  code39mod43: any;
-  code93: any;
-  ean13: any;
-  ean8: any;
-  pdf417: any;
-  qr: any;
-  upce: any;
-  interleaved2of5: any;
-  itf14: any;
-  datamatrix: any;
-}>;
-
-interface Point<T = number> {
-  x: T;
-  y: T;
-}
-
-interface Size<T = number> {
-  width: T;
-  height: T;
-}
-
-export interface Event {
-  data: any;
-  type: keyof BarCodeType;
-  /**
-   * @description For Android use `[Point<string>, Point<string>]`
-   * @description For iOS use `{ origin: Point<string>, size: Size<string> }`
-   */
-  bounds:
-    | [Point<string>, Point<string>]
-    | { origin: Point<string>; size: Size<string> };
-}
+import { RNCameraProps, BarCodeReadEvent } from 'react-native-camera';
 
 export interface RNQRCodeScannerProps {
-  onRead(e: Event): void;
+  onRead(e: BarCodeReadEvent): void;
   vibrate?: boolean;
   reactivate?: boolean;
   reactivateTimeout?: number;
@@ -85,7 +48,7 @@ export default class QRCodeScanner extends Component<
   disable(): void;
   enable(): void;
   _setScanning(value: boolean): void;
-  _handleBarCodeRead(e: Event): void;
+  _handleBarCodeRead(e: BarCodeReadEvent): void;
   _renderTopContent(): JSX.Element | null;
   _renderBottomContent(): JSX.Element | null;
   _renderCameraMarker(): JSX.Element | null;


### PR DESCRIPTION
- We don't need to copy types from RNCamera when we can import them from the library

ref https://github.com/react-native-community/react-native-camera/blob/master/types/index.d.ts#L142