### PR TITLE
use height instead of width

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ export default class QRCodeScanner extends Component {
 					flex: 0,
 					alignItems: 'center',
 					justifyContent: 'center',
-					height: Dimensions.get('window').width,
+					height: Dimensions.get('window').height,
 					width: Dimensions.get('window').width,
 					backgroundColor: 'black',
 				}}


### PR DESCRIPTION
use height instead of width, complements the following PR:
https://github.com/moaazsidat/react-native-qrcode-scanner/pull/269