### PR TITLE
Camera Timeout React Memory Leak Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ export default class QRCodeScanner extends Component {
       isAuthorizationChecked: false,
       disableVibrationByUser: false,
     };
-
+    this.timer = null;
     this._scannerTimeout = null;
     this._handleBarCodeRead = this._handleBarCodeRead.bind(this);
   }
@@ -178,6 +178,10 @@ export default class QRCodeScanner extends Component {
     if (this._scannerTimeout !== null) {
       clearTimeout(this._scannerTimeout);
     }
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+    }
+    this.timer = null;
     this._scannerTimeout = null;
   }
 


### PR DESCRIPTION
The timer is not cleared when the component is unmounted during the set time period of camera timeout.