### PR TITLE
Revert camera view height back to screen width

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: 'transparent',
-    height: Dimensions.get('window').height,
+    height: Dimensions.get('window').width,
     width: Dimensions.get('window').width,
   },
 


### PR DESCRIPTION
Fixing a change in d7ff8325cd557a944d3a7b71165d8dcc509bb6a4 that broke the default display height of the camera as discussed in #307. The camera view height can still be overidden using the cameraStyle prop.

I believe it makes more sense to default to the screen width as QR codes are square and this gives us a 1:1 aspect ratio. It also means the example shown in the README will actually work as originally intended.