### PR TITLE
chore: use new async-storage location

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/moaazsidat/react-native-qrcode-scanner/issues"
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.6.1",
+    "@react-native-async-storage/async-storage": "^1.13.4",
     "prop-types": "^15.5.10",
     "react-native-permissions": "^2.0.2"
   },


### PR DESCRIPTION
react-native-community had a big reorganization and lots of packages were ejected
some of those packages maintained the old `@react-native-community/` npmjs.com namespace
but some have moved to new namespace. async-storage has moved to new namespace (and released)