### PR TITLE
Allow separate style for camera and for container (view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ propType: `any`
 
 Use this to pass or overwrite styling for the camera window rendered.
 
+#### `cameraContainerStyle`
+
+propType: `any`
+
+Use this to pass or overwrite styling for the camera container (view) window rendered.
+
 #### `topViewStyle`
 
 propType: `any`

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ export default class QRCodeScanner extends Component {
     customMarker: PropTypes.element,
     containerStyle: PropTypes.any,
     cameraStyle: PropTypes.any,
+    cameraContainerStyle: PropTypes.any,
     markerStyle: PropTypes.any,
     topViewStyle: PropTypes.any,
     bottomViewStyle: PropTypes.any,
@@ -349,7 +350,7 @@ export default class QRCodeScanner extends Component {
         <View style={[styles.infoView, this.props.topViewStyle]}>
           {this._renderTopContent()}
         </View>
-        <View style={this.props.cameraStyle}>{this._renderCamera()}</View>
+        <View style={this.props.cameraContainerStyle}>{this._renderCamera()}</View>
         <View style={[styles.infoView, this.props.bottomViewStyle]}>
           {this._renderBottomContent()}
         </View>


### PR DESCRIPTION
With this modification, it's now possible the have a specific style for the View where the camera object is. 

It's allow, for example to set a border + margin to the container. Without this it was not possible (border + margin was repeated two time...)
