### PR TITLE
Fix the release ci process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
The previous three commits have not been deployed to npm, and this seems to be due to the `deploy` GitHub action failing on the `semantic-release` step (https://github.com/moaazsidat/react-native-qrcode-scanner/runs/4049234410?check_suite_focus=true)

This PR changes the required node version to 14, which should fix the issue that `semantic-release` is failing on (`[semantic-release]: node version >=14.17 is required. Found v12.22.7.`

I haven't been able to test the deploy process using node 14, so I'm not sure if there are any new issues created by this node version change.

I'm hopeful that it will allow the previous commits to be deployed to npm though 🤞 