### PR TITLE
Remove console.log from static type

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ export default class QRCodeScanner extends Component {
   };
 
   static defaultProps = {
-    onRead: () => console.log('QR code scanned!'),
+    onRead: () => null,
     reactivate: false,
     vibrate: true,
     reactivateTimeout: 0,


### PR DESCRIPTION
When i previously used this functionality, and when i review the adb logcat i see this console.log, i removed it in order to remove this console.log and clean a little bit the code