### PR TITLE
feat: upgrade react-native-permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qrcode-scanner",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A QR code scanner for React Native.",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-native-permissions": "^2.0.2"
+    "react-native-permissions": "^3.6.0"
   },
   "devDependencies": {
     "@semantic-release/git": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,10 +2380,10 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-react-native-permissions@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.0.3.tgz#b6da83e5e313e41ba5f70ff2c4567291766b0140"
-  integrity sha512-8pd+UhyphAiFGzBil5d5pDxRf/rH+20SzDNu9cFnCtoD2MbYTVH7GjXsxaZ2lPsmwrqYYbF8FBfwmncKf/G1+Q==
+react-native-permissions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.6.0.tgz#4b284b6374fdb8b9b6702c6a0719bfb1a97aa7ff"
+  integrity sha512-aiancYU5eAC3lCtdAFNz/8OQAShAXSgFJAcNrsspXiMulL4zjClIa52uWMi5NTU4skU0KoWG5rCfqjxWAkJL8w==
 
 readable-stream@^2.2.2:
   version "2.3.6"


### PR DESCRIPTION
Incompability when using react-native-permissions 2.0.2 (from this package) and in parallel with react-native-permissions 3.6.0

See [!386](https://github.com/moaazsidat/react-native-qrcode-scanner/issues/386)
